### PR TITLE
0.8.17: fix call to get_distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install --upgrade build twine; # Install build tools: build 1.2.2.post1, twi
 python -m build; # Create source distribution and wheel
 twine check dist/*; # Check the distribution
 twine upload --repository testpypi dist/*; # Upload to TestPyPI
-pip install --pre --index-url https://test.pypi.org/simple/ gx-sqlalchemy-redshift; # test download
+pip install --index-url https://test.pypi.org/simple/ gx-sqlalchemy-redshift; # test download
 twine upload dist/*; # Upload to production PyPI
 pip install gx-sqlalchemy-redshift; # test download
 ```

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ history = open('CHANGES.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='gx-sqlalchemy-redshift',
-    version='0.8.16',
+    version='0.8.17',
     description='Great Expectations fork of the Amazon Redshift sqlalchemy dialect',
     long_description=history,
     long_description_content_type='text/x-rst',

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -8,7 +8,7 @@ for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
     except DistributionNotFound:
         pass
 
-__version__ = get_distribution('sqlalchemy-redshift').version
+__version__ = get_distribution('gx-sqlalchemy-redshift').version
 
 from sqlalchemy.dialects import registry  # noqa
 


### PR DESCRIPTION
- the pip package name (gx-sqlalchemy-redshift) is different than the python package name (`sqlalchemy_redshift`, or its alias `redshift_sqlalchemy`)